### PR TITLE
ipyvizzu.Chart.animation: allow distinct animations

### DIFF
--- a/ipyvizzu.py
+++ b/ipyvizzu.py
@@ -6,7 +6,7 @@ import json
 import abc
 import typing
 
-from IPython.display import HTML, display_html
+from IPython.display import display_html
 
 
 _HEAD = """
@@ -119,7 +119,7 @@ class Chart:
     Wrapper over vizzu Chart
     """
 
-    def __init__(self, **data):
+    def __init__(self):
         self._calls = []
 
     def feature(self, name, value):


### PR DESCRIPTION
All Animation has a main key (Data => "data", Config => "config")
therefore it is quite straightforward to merge different animation in
one `Chart.animate` call. Therefore `Chart.animate` can allow multiple
animations until they do not override any data.

The `*animations` and `**config` can be merged with this strategy, too
and the *args and **kwargs calls will lokk similar:

  Chart().animate(config={...}, data={...})

  Chart().animate(Config(...), Data(...))