### PR TITLE
Adding `jsonschema` to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 IPython
+jsonschema
 pandas


### PR DESCRIPTION
This adds missing dependency `jsonschema` to requirements.txt.

Closes #187.