### PR TITLE
Documentation: preview videos loading in older Safari browser fixed

### DIFF
--- a/tools/docs/examples/gen_examples.py
+++ b/tools/docs/examples/gen_examples.py
@@ -225,15 +225,15 @@ class GenExamples:
             if figcaption:
                 html.append("<figure markdown class='image-figure'>")
                 html.append(
-                    "<video nocontrols autoplay muted loop class='image-gallery-w-caption'"
+                    "<video nocontrols autoplay muted loop class='image-gallery-w-caption'>"
                 )
             else:
                 html.append(
-                    "<video nocontrols autoplay muted loop class='image-gallery'"
+                    "<video nocontrols autoplay muted loop class='image-gallery'>"
                 )
-            html.append(f" src='{url}/{thumbnail}.webm'")
+            html.append(f"<source src='{url}/{thumbnail}.webm'")
             html.append(" type='video/webm'>")
-            html.append(f" src='{url}/{thumbnail}.mp4'")
+            html.append(f"<source src='{url}/{thumbnail}.mp4'")
             html.append(" type='video/mp4'>")
             html.append("</video>")
             if figcaption:


### PR DESCRIPTION
fix src attributes for example videos (fixes vizzu-lib-doc#41)